### PR TITLE
nginx prefix deploy:

### DIFF
--- a/integration-test/docker-compose.yml
+++ b/integration-test/docker-compose.yml
@@ -60,6 +60,20 @@ services:
       - hadoop
       - redis
 
+  nginx:
+    image: nginx:1.13-alpine
+
+    volumes:
+      - ./nginx/pywb.conf:/etc/nginx/conf.d/pywb.conf:ro
+      - ../static:/ukwa-pywb-static
+
+    ports:
+      - "8100:8100"
+
+    depends_on:
+      - pywb
+
+
 # -----------------------------------------------------------
 # Automated test engine
 # -----------------------------------------------------------

--- a/integration-test/nginx/pywb.conf
+++ b/integration-test/nginx/pywb.conf
@@ -1,0 +1,59 @@
+resolver 127.0.0.11 ipv6=off;
+
+server {
+    listen 8100;
+
+    location /wayback/static/ {
+        alias /ukwa-pywb-static;
+        try_files $uri @default;
+    }
+
+    location @default {
+        rewrite ^/wayback/(.*) /$1 break;
+
+        include uwsgi_params;
+        uwsgi_param UWSGI_SCHEME $scheme;
+        uwsgi_param SCRIPT_NAME /wayback;
+
+        uwsgi_pass pywb:8081;
+    }
+
+    # remove /wayback/ prefix, pass to pywb
+    location /wayback/ {
+        rewrite ^/wayback/(.*) /$1 break;
+
+        include uwsgi_params;
+        uwsgi_param UWSGI_SCHEME $scheme;
+        uwsgi_param SCRIPT_NAME /wayback;
+
+        uwsgi_pass pywb:8081;
+
+        uwsgi_force_ranges on;
+
+        uwsgi_buffer_size 64k;
+        uwsgi_buffers 16 64k;
+        uwsgi_busy_buffers_size 64k;
+
+        uwsgi_request_buffering off;
+        uwsgi_buffering off; 
+    }
+
+    # no rewrite needed, just pass to pywb
+    location / {
+        include uwsgi_params;
+        uwsgi_param UWSGI_SCHEME $scheme;
+
+        uwsgi_pass pywb:8081;
+
+        uwsgi_force_ranges on;
+
+        uwsgi_buffer_size 64k;
+        uwsgi_buffers 16 64k;
+        uwsgi_busy_buffers_size 64k;
+
+        uwsgi_request_buffering off;
+        uwsgi_buffering off; 
+    }
+
+}
+

--- a/integration-test/robot/tests/fixup_inject.robot
+++ b/integration-test/robot/tests/fixup_inject.robot
@@ -10,16 +10,21 @@ Init Requests
 
 Fix-Up Included In Replay
     ${resp}=    Get Request    pywb    /qa-access/20180203004147mp_/http://acid.matkelly.com/
-    Should Contain    ${resp.text}    <script src="/static/fixup.js">
+    Should Contain    ${resp.text}    <script src="http://pywb:8080/static/fixup.js">
  
 Fix-Up Not Included Top Frame
     ${resp}=    Get Request    pywb    /qa-access/20180203004147/http://acid.matkelly.com/
-    Should Not Contain    ${resp.text}    <script src="/static/fixup.js">
+    Should Not Contain    ${resp.text}    /static/fixup.js
 
-Fix-Up Included In Proxy Replay
+Fix-Up Included In HTTP Proxy Replay
     ${proxies} =    Evaluate    {"https": "https://pywb:8080/", "http": "http://pywb:8080/"}
     Create Session    proxy    http://acid.matkelly.com    proxies=${proxies}
     ${resp}=    Get Request    proxy    /
-    Should Contain    ${resp.text}    <script src="/static/fixup.js">
+    Should Contain    ${resp.text}    <script src="http://pywb.proxy/static/fixup.js">
  
- 
+Fix-Up Included In HTTPS Proxy Replay
+    ${proxies} =    Evaluate    {"https": "https://pywb:8080/", "http": "http://pywb:8080/"}
+    Create Session    proxy    https://acid.matkelly.com    proxies=${proxies}
+    ${resp}=    Get Request    proxy    /
+    Should Contain    ${resp.text}    <script src="https://pywb.proxy/static/fixup.js">
+  

--- a/static/default_banner.js
+++ b/static/default_banner.js
@@ -53,11 +53,11 @@ This file is part of pywb, https://github.com/webrecorder/pywb
 
     function changeLanguage(lang, evt) {
         evt.preventDefault();
-        var path = window.location.pathname;
-        if (window.banner_info.curr_locale) {
-            path = path.replace(new RegExp("^/"+window.banner_info.curr_locale), "");
+        var path = window.location.href;
+        if (path.indexOf(window.banner_info.prefix) == 0) {
+          path = path.substring(window.banner_info.prefix.length);
+          window.location.pathname = window.banner_info.locale_prefixes[lang] + path;
         }
-        window.location = "/" + lang + path;
     }
 
     function init(bid) {
@@ -69,7 +69,7 @@ This file is part of pywb, https://github.com/webrecorder/pywb
         var logo = document.createElement("a");
         logo.setAttribute("href", "/" + (window.banner_info.locale ? window.banner_info.locale + "/" : ""));
         logo.setAttribute("class", "_wb_linked_logo");
-        logo.innerHTML = "<img src='/static/ukwa.svg' alt='" + window.banner_info.logoAlt + "'><img src='/static/ukwa-condensed.svg' class='mobile' alt='" + window.banner_info.logoAlt + "'>";
+        logo.innerHTML = "<img src='" + window.banner_info.staticPrefix + "/ukwa.svg' alt='" + window.banner_info.logoAlt + "'><img src='" + window.banner_info.staticPrefix + "/ukwa-condensed.svg' class='mobile' alt='" + window.banner_info.logoAlt + "'>";
         banner.appendChild(logo);
 
         var captureInfo = document.createElement("div");
@@ -83,7 +83,7 @@ This file is part of pywb, https://github.com/webrecorder/pywb
         var calendarLink = document.createElement("a");
         calendarLink.setAttribute("href", "#");
         calendarLink.addEventListener("click", backToCalendar);
-        calendarLink.innerHTML = "<img src='/static/calendar.svg' alt='" + window.banner_info.calendarAlt + "'><span class='no-mobile'>&nbsp;" +window.banner_info.calendarLabel + "</span>";
+        calendarLink.innerHTML = "<img src='" + window.banner_info.staticPrefix + "/calendar.svg' alt='" + window.banner_info.calendarAlt + "'><span class='no-mobile'>&nbsp;" +window.banner_info.calendarLabel + "</span>";
         ancillaryLinks.appendChild(calendarLink);
 
         if (typeof window.banner_info.locales !== "undefined" && window.banner_info.locales.length) {

--- a/templates/banner.html
+++ b/templates/banner.html
@@ -1,11 +1,11 @@
 {% if not embed_url %}
 <!-- Custom Fixup Script -->
-<script src="/static/fixup.js"> </script>
+<script src="{{ static_prefix }}/fixup.js"> </script>
 {% endif %}
 
 <!-- default banner, create through js -->
-<script src='{{ host_prefix }}/{{ static_path }}/default_banner.js'> </script>
-<link rel='stylesheet' href='{{ host_prefix }}/{{ static_path }}/default_banner.css'/>
+<script src='{{ static_prefix }}/default_banner.js'> </script>
+<link rel='stylesheet' href='{{ static_prefix }}/default_banner.css'/>
 <script>
 window.banner_info = {
     ARCHIVED_ON: decodeURIComponent("{{ _Q('Archived On:') }}"),
@@ -19,7 +19,9 @@ window.banner_info = {
     locale: "{{ env.pywb_lang | default('en') }}",
     curr_locale: "{{ env.pywb_lang }}",
     locales: {{ locales }},
-    prefix: "{{ wb_prefix }}"
+    locale_prefixes: {{ get_locale_prefixes() | tojson }},
+    prefix: "{{ wb_prefix }}",
+    staticPrefix: "{{ static_prefix }}"
 };
 window.activeUrl = "{{ url }}";
 </script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,9 +3,9 @@
     <head>
         <title>UKWA Pywb Access System</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="shortcut icon" href="/static/images/favicon.png">
-        <link rel="stylesheet" type="text/css" href="/static/base.css">
-        <script src="/static/base.js"> </script>
+        <link rel="shortcut icon" href="{{ static_prefix }}/images/favicon.png">
+        <link rel="stylesheet" type="text/css" href="{{ static_prefix }}/base.css">
+        <script src="{{ static_prefix }}/base.js"> </script>
 
         {% block head %}
         {% endblock %}
@@ -13,8 +13,8 @@
     <body>
         {% block header %}
         <header>
-            <a href="/{{ env.pywb_lang | default('en') }}/" class="logo">
-                <img src="/static/ukwa-full.svg" width="200" height="133" alt="{{ _('UK Web Archive logo') }}">
+            <a href="{{ env.ORIG_SCRIPT_NAME }}/{{ env.pywb_lang + '/' if env.pywb_lang else ''}}" class="logo">
+                <img src="{{ static_prefix }}/ukwa-full.svg" width="200" height="133" alt="{{ _('UK Web Archive logo') }}">
             </a>
             {% if not no_lang %}
             <div class="language-select">

--- a/templates/frame_insert.html
+++ b/templates/frame_insert.html
@@ -23,7 +23,7 @@ html, body
 }
 
 </style>
-<script src='{{ host_prefix }}/{{ static_path }}/wb_frame.js'> </script>
+<script src='{{ static_prefix }}/wb_frame.js'> </script>
 
 {{ banner_html }}
 

--- a/templates/query.html
+++ b/templates/query.html
@@ -2,12 +2,12 @@
 
 {% block head %}
     <!-- jquery and bootstrap dependencies query view -->
-    <link rel="stylesheet" href="{{ host_prefix }}/{{ static_path }}/css/query.css">
-    <link rel="stylesheet" href="{{ host_prefix }}/{{ static_path }}/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ host_prefix }}/{{ static_path }}/css/font-awesome.min.css">
-    <script src="{{ host_prefix }}/{{ static_path }}/js/jquery-latest.min.js"></script>
-    <script src="{{ host_prefix }}/{{ static_path }}/js/bootstrap.min.js"></script>
-    <script src="{{ host_prefix }}/{{ static_path }}/query.js"></script>
+    <link rel="stylesheet" href="{{ static_prefix }}/css/query.css">
+    <link rel="stylesheet" href="{{ static_prefix }}/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ static_prefix }}/css/font-awesome.min.css">
+    <script src="{{ static_prefix }}/js/jquery-latest.min.js"></script>
+    <script src="{{ static_prefix }}/js/bootstrap.min.js"></script>
+    <script src="{{ static_prefix }}/query.js"></script>
     <script>
         var Text = {
           months: {

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -7,7 +7,7 @@ endif =
 master = true
 buffer-size = 65536
 die-on-term = true
-route-run = fixpathinfo:
+#route-run = fixpathinfo:
 
 if-env = VIRTUAL_ENV
 venv = $(VIRTUAL_ENV)


### PR DESCRIPTION
- add nginx container, which routes to pywb at '/wayback' prefix (as well as at root)
- ensure language switching works with prefixed deployment, eg. /wayback/en -> /wayback/cy
- update static paths to use new '{{ static_prefix }}'
- update robot tests to check for absolute fixup.js script path

Fixes for running with custom prefix/non-root deployment.
Fixes language switching in the UI, ensures static content also served from prefix. Requires ukwa/pywb#2.
Sample nginx container is configured to run pywb at `/wayback/`, static assets served from `/wayback/static/` and en and cy localization from `/wayback/en/` and `/wayback/cy/` respectively