### PR TITLE
Reference and search improvements

### DIFF
--- a/static/viewers/epub_viewer/js/reader.js
+++ b/static/viewers/epub_viewer/js/reader.js
@@ -3309,7 +3309,9 @@ EPUBJS.Reader = function(bookPath, _options) {
 
 		window.addEventListener("hashchange", this.hashChanged.bind(this), false);
 
-		document.addEventListener('keydown', this.adjustFontSize.bind(this), false);
+		document.addEventListener("keydown", this.adjustFontSize.bind(this), false);
+
+    window.addEventListener("keydown", this.searchOverride.bind(this), false);
 
 		this.rendition.on("keydown", this.adjustFontSize.bind(this));
 		this.rendition.on("keydown", reader.ReaderController.arrowKeys.bind(this));
@@ -3337,6 +3339,23 @@ EPUBJS.Reader = function(bookPath, _options) {
 	window.addEventListener("beforeunload", this.unload.bind(this), false);
 
 	return this;
+};
+
+EPUBJS.Reader.prototype.searchOverride = function (e) {
+  // Override ctrl-f to instead display and focus on in-app search feature
+  var reader = this;
+
+  if (e.which === 114 || ((e.ctrlKey || e.metaKey) && e.which === 70)) { 
+    e.preventDefault();
+
+    // Open sidebar to Citation panel
+    reader.SidebarController.show();
+    reader.SidebarController.changePanelTo("Citation");
+
+    // Focus on search input
+    $searchInput = $("#search-input");
+    $searchInput.trigger("focus");
+  }
 };
 
 EPUBJS.Reader.prototype.adjustFontSize = function(e) {
@@ -4539,6 +4558,7 @@ EPUBJS.reader.SettingsController = function() {
 		"hide" : hide
 	};
 };
+
 EPUBJS.reader.SidebarController = function(book) {
 	var reader = this;
 

--- a/static/viewers/epub_viewer/js/reader.js
+++ b/static/viewers/epub_viewer/js/reader.js
@@ -3561,9 +3561,8 @@ EPUBJS.Reader.prototype.getSpineItemFromChapterNumber = function(spineItems, cha
 };
 
 EPUBJS.Reader.prototype.getSpineItemParagraphs = function(spineItem){
-  var spineItemDoc;
   var paragraphs = spineItem.load(this.book.load.bind(this.book)).then((contents) => {
-    spineItemDoc = contents;
+    var spineItemDoc = contents;
     var pNodes = spineItemDoc.body.getElementsByTagName("p");
     var paragraphs = [...Array(pNodes.length).keys()].map((pIndex) => {
       var pNode = spineItemDoc.body.getElementsByTagName("p").item(pIndex);
@@ -3757,7 +3756,7 @@ EPUBJS.reader.CitationController = function() {
     var cfi = reader.getCfiFromCalibreRef(ref);
     rendition.display(cfi);
     // TODO: Highlight
-    // rendition.annotations.highlight(cfi);
+    rendition.annotations.highlight(cfi);
   };
 
   var goToCFI = function() {
@@ -3766,7 +3765,7 @@ EPUBJS.reader.CitationController = function() {
     // into title case for some reason
     cfiStr = cfiStr.charAt(0).toLowerCase() + cfiStr.slice(1);
     rendition.display(cfiStr);
-    // rendition.annotations.highlight(cfiStr);
+    rendition.annotations.highlight(cfiStr);
   };
 
   var doSearch = function(q) {

--- a/static/viewers/epub_viewer/js/reader.js
+++ b/static/viewers/epub_viewer/js/reader.js
@@ -3589,6 +3589,7 @@ EPUBJS.Reader.prototype.getParagraphNumberFromCFI = function(spineItem, cfi){
 };
 
 EPUBJS.Reader.prototype.getCfiFromParagraphNumber = function(spineItem, paragraphNumber){
+  // returns a Promise
   return spineItem.load(this.book.load.bind(this.book)).then((contents) => {
     var spineItemDoc = contents;
     var foundCfi;

--- a/static/viewers/epub_viewer/js/reader.js
+++ b/static/viewers/epub_viewer/js/reader.js
@@ -3527,7 +3527,6 @@ EPUBJS.Reader.prototype.getCfiFromHref = function(href){
 EPUBJS.Reader.prototype.gotoCalibreRef = function(ref){
   // Go to chapter/paragraph indicated by Calibre-style reference
   // If reference doesn't resolve, instead go to beginning of chapter
-
   var reader = this;
   var book = this.book;
   var rendition = this.rendition;

--- a/static/viewers/epub_viewer/js/reader.js
+++ b/static/viewers/epub_viewer/js/reader.js
@@ -3561,13 +3561,18 @@ EPUBJS.Reader.prototype.getSpineItemFromChapterNumber = function(spineItems, cha
 };
 
 EPUBJS.Reader.prototype.getSpineItemParagraphs = function(spineItem){
-  var pNodes = spineItem.document.body.getElementsByTagName("p");
-  var paragraphs = [...Array(pNodes.length).keys()].map((pIndex) => {
-    var pNode = spineItem.document.body.getElementsByTagName("p").item(pIndex);
-    if (pNode.nodeType == 1) {
-      var cfi = spineItem.cfiFromElement(pNode);
-      return {paragraphNumber: pIndex + 1, cfi: cfi};
-    }
+  var spineItemDoc;
+  var paragraphs = spineItem.load(this.book.load.bind(this.book)).then((contents) => {
+    spineItemDoc = contents;
+    var pNodes = spineItemDoc.body.getElementsByTagName("p");
+    var paragraphs = [...Array(pNodes.length).keys()].map((pIndex) => {
+      var pNode = spineItemDoc.body.getElementsByTagName("p").item(pIndex);
+      if (pNode.nodeType == 1) {
+        var cfi = spineItem.cfiFromElement(pNode);
+        return {paragraphNumber: pIndex + 1, cfi: cfi};
+      }
+    });
+    return paragraphs;
   });
   return paragraphs;
 };


### PR DESCRIPTION
- [x] Load spine item prior to going to reference to ensure it always works, even if chapter hasn't been visited in this session yet
- [x] Highlight paragraph corresponding to reference (implemented: highlights first character of paragraph as indicator; might be able to come back to highlighting the whole thing later but it proved to be difficult/a big time sink so decided to move on for now)
- [X] Override browser's ctrl/cmd-f behavior; display in-app search sidebar and focus on input instead of opening browser find widget