### PR TITLE
Add print selection button to print view that prints only contents of rendition iframe

### DIFF
--- a/static/viewers/epub_viewer/js/epub.js
+++ b/static/viewers/epub_viewer/js/epub.js
@@ -9458,7 +9458,7 @@ class IframeView {
 
     this.iframe.style.border = "none"; // sandbox
 
-    this.iframe.sandbox = "allow-same-origin";
+    this.iframe.sandbox = "allow-same-origin allow-modals";
 
     if (this.settings.allowScriptedContent) {
       this.iframe.sandbox += " allow-scripts";

--- a/static/viewers/epub_viewer/print-friendly.html
+++ b/static/viewers/epub_viewer/print-friendly.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Print Mode</title>
+    <title>UKWA Epub Viewer Print Mode</title>
 
     <link rel="stylesheet" href="css/printfriendly.css">
 
@@ -14,6 +14,7 @@
 
   <body>
     <button id="backToMainView">Back to main view</button>
+    <button id="printSelection">Print selection</button>
     <select id="toc"></select>
     <div id="viewer" class="scrolled"></div>
 
@@ -31,12 +32,21 @@
       rendition.display();
 
       var $backToMain = $("#backToMainView");
+      var $print = $("#printSelection");
 
       $backToMain.on("click", function(){
         var currentUrl = window.location.href;
         const mainViewUrl = currentUrl.replace("print-friendly.html", "index.html").split("#")[0];
         window.location.href = mainViewUrl;
       });
+
+      $print.on("click", function(){
+        printIFrameContents();
+      });
+
+      function printIFrameContents() {
+        document.querySelector("div.epub-view > iframe").contentWindow.print();
+      }
 
       // TODO: We may want to add the spine items that precede chapters to the
       // select as well (e.g. cover, table of contents). This may be trickier


### PR DESCRIPTION
Fixes #111 

- Adds "Print selection" button to print-friendly view
- Printing via "Print selection" button prints only the rendition iframe's content
- In testing, this also allows for printing a range of pages, which should also fix LDVB_28, LDVB_29, and LDVB_30 (but notably I wasn't able to reproduce these issues in Chromium, Chrome, or Firefox - to try again now that we're using auto-detect for epub file type)